### PR TITLE
Update actions/setup-node v2.0.0 -> v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2.0.0
+      - uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: '12'
 
       - run: yarn install
 


### PR DESCRIPTION
## What this PR does / Why we need it

Updated [`actions/setup-node`](https://github.com/actions/setup-node) to [v2](https://github.com/actions/setup-node/releases/tag/v2).

## Which issue(s) this PR fixes

None
