### PR TITLE
Make `github_token` input optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It would be more useful to use this with other GitHub Actions' outputs.
 
 |      NAME       |                                           DESCRIPTION                                           |   TYPE   | REQUIRED |                                     DEFAULT                                     |
 | --------------- | ----------------------------------------------------------------------------------------------- | -------- | -------- | ------------------------------------------------------------------------------- |
-| `github_token`  | A GitHub token.                                                                                 | `string` | `true`   | `N/A`                                                                           |
+| `github_token`  | A GitHub token.                                                                                 | `string` | `false`   | `${{ github.token }}`                                                                           |
 | `labels`        | The labels' name to be removed. Must be separated with line breaks if there're multiple labels. | `string` | `true`   | `N/A`                                                                           |
 | `number`        | The number of the issue or pull request.                                                        | `number` | `false`  | `N/A`                                                                           |
 | `repo`          | The owner and repository name. e.g.) `Codertocat/Hello-World`                                   | `string` | `false`  | `${{ github.event.issue.number }}` or `${{ github.event.pull_request.number }}` |
@@ -40,7 +40,6 @@ jobs:
       - uses: actions-ecosystem/action-remove-labels@v1
         if: ${{ startsWith(github.event.comment.body, '/remove-labels') }}
         with:
-          github_token: ${{ secrets.github_token }}
           labels: bug
 ```
 
@@ -59,7 +58,6 @@ jobs:
       - uses: actions-ecosystem/action-remove-labels@v1
         if: ${{ startsWith(github.event.comment.body, '/remove-labels') }}
         with:
-          github_token: ${{ secrets.github_token }}
           labels: |
             documentation
             changelog

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,8 @@ author: The Actions Ecosystem Authors
 inputs:
   github_token:
     description: A GitHub token.
-    required: true
+    required: false
+    default: ${{ github.token }}
   labels:
     description: The labels' name to be removed. Must be separated with line breaks if there're multiple labels.
     required: true


### PR DESCRIPTION
## What this PR does / Why we need it

The action has access to `${{ github.token }}` anyway, so let's make it optional to pass as input

This is the same change as https://github.com/actions-ecosystem/action-add-labels/pull/160