### PR TITLE
Continue removing labels with errors

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -952,13 +952,23 @@ function run() {
                 return;
             }
             const client = github.getOctokit(githubToken);
+            const remaining = [];
             for (const label of labels) {
-                yield client.issues.removeLabel({
-                    name: label,
-                    owner,
-                    repo,
-                    issue_number: number
-                });
+                try {
+                    yield client.issues.removeLabel({
+                        name: label,
+                        owner,
+                        repo,
+                        issue_number: number
+                    });
+                }
+                catch (e) {
+                    core.warning(`failed to remove label: ${label}: ${e}`);
+                    remaining.push(label);
+                }
+            }
+            if (remaining.length) {
+                throw new Error(`failed to remove labels: ${remaining}`);
             }
         }
         catch (e) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,13 +21,23 @@ async function run(): Promise<void> {
 
     const client = github.getOctokit(githubToken);
 
+    const remaining = [];
     for (const label of labels) {
-      await client.issues.removeLabel({
-        name: label,
-        owner,
-        repo,
-        issue_number: number
-      });
+      try {
+        await client.issues.removeLabel({
+          name: label,
+          owner,
+          repo,
+          issue_number: number
+        });
+      } catch (e) {
+        core.warning(`failed to remove label: ${label}: ${e}`);
+        remaining.push(label);
+      }
+    }
+
+    if (remaining.length) {
+      throw new Error(`failed to remove labels: ${remaining}`);
     }
   } catch (e) {
     core.error(e);


### PR DESCRIPTION
## What this PR does / Why we need it

This PR lets the action continue removing labels even if there is an error during removing other labels.

```yaml
      - name: Remove labels
        uses: actions-ecosystem/action-remove-labels@v1.1.0
        with:
          labels: |
            A
            B
            C
```

In the above example, previously, if the label A and C exist but B doesn't, C won't be removed. With this change, the action will remove A and C in this case.

## Which issue(s) this PR fixes

Fixes #219
