### PR TITLE
Make github_token no longer required as input

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -939,7 +939,7 @@ const core = __importStar(__webpack_require__(393));
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const githubToken = core.getInput('github_token', { required: true });
+            const githubToken = core.getInput('github_token');
             const labels = core
                 .getInput('labels')
                 .split('\n')

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import * as core from '@actions/core';
 
 async function run(): Promise<void> {
   try {
-    const githubToken = core.getInput('github_token', { required: true });
+    const githubToken = core.getInput('github_token');
 
     const labels = core
       .getInput('labels')


### PR DESCRIPTION
## What this PR does / Why we need it
This PR removes the `{required: true}` for the github token input.
Similar to [this issue & fix](https://github.com/actions-ecosystem/action-add-labels/pull/259), the token input is no longer required.

## Which issue(s) this PR fixes
[issue 272](https://github.com/actions-ecosystem/action-remove-labels/issues/272)