### PR TITLE
Remove `- uses: actions/checkout@v2` in README.md as it's not necessary to use the action 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ jobs:
   remove_label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: actions-ecosystem/action-remove-labels@v1
         if: ${{ startsWith(github.event.comment.body, '/remove-labels') }}
         with:
@@ -54,7 +53,6 @@ jobs:
   remove_labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - uses: actions-ecosystem/action-remove-labels@v1
         if: ${{ startsWith(github.event.comment.body, '/remove-labels') }}
         with:


### PR DESCRIPTION
## What this PR does / Why we need it

Gives a better default usage of the actions, people copy pasting the README code may have the additional checkout that is not necessary (I know because I've seen it 🙂 )

## Which issue(s) this PR fixes

None