### PR TITLE
Upgrade action to use node 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version: '16'
 
       - run: yarn install
 

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     default: 'false'
     required: false
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
 branding:
   icon: bookmark


### PR DESCRIPTION
## What this PR does / Why we need it

Node 12 is being [deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) in GitHub Actions. This PR updates `action.yml` to use Node 16

## Which issue(s) this PR fixes

Upgrades node version runner to 16

Fixes #413 
