### PR TITLE
Use node v16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     default: 'false'
     required: false
 runs:
-  using: node12
+  using: node14
   main: dist/index.js
 branding:
   icon: bookmark

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     default: 'false'
     required: false
 runs:
-  using: node14
+  using: node16
   main: dist/index.js
 branding:
   icon: bookmark


### PR DESCRIPTION
## What this PR does / Why we need it

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

## Fixes

Fixes https://github.com/actions-ecosystem/action-remove-labels/issues/413